### PR TITLE
Fix wrong regexp in restore

### DIFF
--- a/backup/moodle2/restore_qtype_ddmatch_plugin.class.php
+++ b/backup/moodle2/restore_qtype_ddmatch_plugin.class.php
@@ -211,11 +211,11 @@ class restore_qtype_ddmatch_plugin extends restore_qtype_plugin {
                 // Cache all cleaned answers and questiontext.
                 foreach ($potentialsubs as $potentialsub) {
                     // Clean in the same way than {@link xml_writer::xml_safe_utf8()}.
-                    $cleanquestion = preg_replace('/[\x-\x8\xb-\xc\xe-\x1f\x7f]/is',
+                    $cleanquestion = preg_replace('/[\x00-\x08\x0b-\x0c\x0e-\x1f\x7f]/i',
                             '', $potentialsub->questiontext); // Clean CTRL chars.
                     $cleanquestion = preg_replace("/\r\n|\r/", "\n", $cleanquestion); // Normalize line ending.
 
-                    $cleananswer = preg_replace('/[\x-\x8\xb-\xc\xe-\x1f\x7f]/is',
+                    $cleananswer = preg_replace('/[\x00-\x08\x0b-\x0c\x0e-\x1f\x7f]/i',
                             '', $potentialsub->answertext); // Clean CTRL chars.
                     $cleananswer = preg_replace("/\r\n|\r/", "\n", $cleananswer); // Normalize line ending.
 


### PR DESCRIPTION
Align regexp to the one in core_text::trim_ctrl_chars.